### PR TITLE
Refactor to setup.cfg, lint and cleanup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: Python Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [2.7, 3.7, 3.8, 3.9]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade setuptools tox
+      - name: Run Tests
+        working-directory: library
+        run: |
+          tox -e py
+      - name: Coverage
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        working-directory: library
+        run: |
+          python -m pip install coveralls
+          coveralls --service=github
+        if: ${{ matrix.python == '3.9' }}
+

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ __pycache__
 packaging/*tar.xz
 library/debian/
 sphinx.virtualenv/
+.coverage
+.pytest_cache
+.tox

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,70 @@
+LIBRARY_VERSION=$(shell grep version library/setup.cfg | awk -F" = " '{print $$2}')
+LIBRARY_NAME=$(shell grep name library/setup.cfg | awk -F" = " '{print $$2}')
+
+.PHONY: usage install uninstall
+usage:
+	@echo "Library: ${LIBRARY_NAME}"
+	@echo "Version: ${LIBRARY_VERSION}\n"
+	@echo "Usage: make <target>, where target is one of:\n"
+	@echo "install:       install the library locally from source"
+	@echo "uninstall:     uninstall the local library"
+	@echo "check:         peform basic integrity checks on the codebase"
+	@echo "python-readme: generate library/README.md from README.md + library/CHANGELOG.txt"
+	@echo "python-wheels: build python .whl files for distribution"
+	@echo "python-sdist:  build python source distribution"
+	@echo "python-clean:  clean python build and dist directories"
+	@echo "python-dist:   build all python distribution files"
+	@echo "python-testdeploy: build all and deploy to test PyPi"
+	@echo "tag:           tag the repository with the current version"
+
+install:
+	./install.sh
+
+uninstall:
+	./uninstall.sh
+
+check:
+	@echo "Checking for trailing whitespace"
+	@! grep -IUrn --color "[[:blank:]]$$" --exclude-dir=sphinx --exclude-dir=.tox --exclude-dir=.git --exclude=PKG-INFO
+	@echo "Checking for DOS line-endings"
+	@! grep -IUrn --color "" --exclude-dir=sphinx --exclude-dir=.tox --exclude-dir=.git --exclude=Makefile
+	@echo "Checking library/CHANGELOG.txt"
+	@cat library/CHANGELOG.txt | grep ^${LIBRARY_VERSION}
+	@echo "Checking library/${LIBRARY_NAME}/__init__.py"
+	@cat library/${LIBRARY_NAME}/__init__.py | grep "^__version__ = '${LIBRARY_VERSION}'"
+
+tag:
+	git tag -a "v${LIBRARY_VERSION}" -m "Version ${LIBRARY_VERSION}"
+
+python-readme: library/README.md
+
+python-license: library/LICENSE.txt
+
+library/README.md: README.md library/CHANGELOG.txt
+	cp README.md library/README.md
+	printf "\n# Changelog\n" >> library/README.md
+	cat library/CHANGELOG.txt >> library/README.md
+
+library/LICENSE.txt: LICENSE
+	cp LICENSE library/LICENSE.txt
+
+python-wheels: python-readme python-license
+	cd library; python3 setup.py bdist_wheel
+	-cd library; python setup.py bdist_wheel
+
+python-sdist: python-readme python-license
+	cd library; python3 setup.py sdist
+
+python-clean:
+	-rm -r library/dist
+	-rm -r library/build
+	-rm -r library/*.egg-info
+
+python-dist: python-clean python-wheels python-sdist
+	ls library/dist
+
+python-testdeploy: python-dist
+	twine upload --repository-url https://test.pypi.org/legacy/ library/dist/*
+
+python-deploy: check python-dist
+	twine upload library/dist/*

--- a/examples/launcher.py
+++ b/examples/launcher.py
@@ -17,7 +17,7 @@ Touch pHAT: App Launcher Example
 A: Terminal
 B: Browser
 C: Idle
-D: Dashboard 
+D: Dashboard
 
 Back: Logout
 Enter: Shutdown

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,254 @@
+#!/bin/bash
+
+CONFIG=/boot/config.txt
+DATESTAMP=`date "+%Y-%M-%d-%H-%M-%S"`
+CONFIG_BACKUP=false
+APT_HAS_UPDATED=false
+USER_HOME=/home/$SUDO_USER
+RESOURCES_TOP_DIR=$USER_HOME/Pimoroni
+WD=`pwd`
+USAGE="sudo ./install.sh (--unstable)"
+POSITIONAL_ARGS=()
+UNSTABLE=false
+PYTHON3=`which python3`
+
+user_check() {
+	if [ $(id -u) -ne 0 ]; then
+		printf "Script must be run as root. Try 'sudo ./install.sh'\n"
+		exit 1
+	fi
+}
+
+confirm() {
+	if [ "$FORCE" == '-y' ]; then
+		true
+	else
+		read -r -p "$1 [y/N] " response < /dev/tty
+		if [[ $response =~ ^(yes|y|Y)$ ]]; then
+			true
+		else
+			false
+		fi
+	fi
+}
+
+prompt() {
+	read -r -p "$1 [y/N] " response < /dev/tty
+	if [[ $response =~ ^(yes|y|Y)$ ]]; then
+		true
+	else
+		false
+	fi
+}
+
+success() {
+	echo -e "$(tput setaf 2)$1$(tput sgr0)"
+}
+
+inform() {
+	echo -e "$(tput setaf 6)$1$(tput sgr0)"
+}
+
+warning() {
+	echo -e "$(tput setaf 1)$1$(tput sgr0)"
+}
+
+function do_config_backup {
+	if [ ! $CONFIG_BACKUP == true ]; then
+		CONFIG_BACKUP=true
+		FILENAME="config.preinstall-$LIBRARY_NAME-$DATESTAMP.txt"
+		inform "Backing up $CONFIG to /boot/$FILENAME\n"
+		cp $CONFIG /boot/$FILENAME
+		mkdir -p $RESOURCES_TOP_DIR/config-backups/
+		cp $CONFIG $RESOURCES_TOP_DIR/config-backups/$FILENAME
+		if [ -f "$UNINSTALLER" ]; then
+			echo "cp $RESOURCES_TOP_DIR/config-backups/$FILENAME $CONFIG" >> $UNINSTALLER
+		fi
+	fi
+}
+
+function apt_pkg_install {
+	PACKAGES=()
+	PACKAGES_IN=("$@")
+	for ((i = 0; i < ${#PACKAGES_IN[@]}; i++)); do
+		PACKAGE="${PACKAGES_IN[$i]}"
+		if [ "$PACKAGE" == "" ]; then continue; fi
+		printf "Checking for $PACKAGE\n"
+		dpkg -L $PACKAGE > /dev/null 2>&1
+		if [ "$?" == "1" ]; then
+			PACKAGES+=("$PACKAGE")
+		fi
+	done
+	PACKAGES="${PACKAGES[@]}"
+	if ! [ "$PACKAGES" == "" ]; then
+		echo "Installing missing packages: $PACKAGES"
+		if [ ! $APT_HAS_UPDATED ]; then
+			apt update
+			APT_HAS_UPDATED=true
+		fi
+		apt install -y $PACKAGES
+		if [ -f "$UNINSTALLER" ]; then
+			echo "apt uninstall -y $PACKAGES"
+		fi
+	fi
+}
+
+while [[ $# -gt 0 ]]; do
+	K="$1"
+	case $K in
+	-u|--unstable)
+		UNSTABLE=true
+		shift
+		;;
+	*)
+		if [[ $1 == -* ]]; then
+			printf "Unrecognised option: $1\n";
+			printf "Usage: $USAGE\n";
+			exit 1
+		fi
+		POSITIONAL_ARGS+=("$1")
+		shift
+	esac
+done
+
+user_check
+
+apt_pkg_install python-configparser
+
+CONFIG_VARS=`python - <<EOF
+from configparser import ConfigParser
+c = ConfigParser()
+c.read('library/setup.cfg')
+p = dict(c['pimoroni'])
+# Convert multi-line config entries into bash arrays
+for k in p.keys():
+    fmt = '"{}"'
+    if '\n' in p[k]:
+        p[k] = "'\n\t'".join(p[k].split('\n')[1:])
+        fmt = "('{}')"
+    p[k] = fmt.format(p[k])
+print("""
+LIBRARY_NAME="{name}"
+LIBRARY_VERSION="{version}"
+""".format(**c['metadata']))
+print("""
+PY3_DEPS={py3deps}
+PY2_DEPS={py2deps}
+SETUP_CMDS={commands}
+CONFIG_TXT={configtxt}
+PY3_ONLY={py3only}
+""".format(**p))
+EOF`
+
+if [ $? -ne 0 ]; then
+	warning "Error parsing configuration...\n"
+	exit 1
+fi
+
+eval $CONFIG_VARS
+
+RESOURCES_DIR=$RESOURCES_TOP_DIR/$LIBRARY_NAME
+UNINSTALLER=$RESOURCES_DIR/uninstall.sh
+
+mkdir -p $RESOURCES_DIR
+
+cat << EOF > $UNINSTALLER
+printf "It's recommended you run these steps manually.\n"
+printf "If you want to run the full script, open it in\n"
+printf "an editor and remove 'exit 1' from below.\n"
+exit 1
+EOF
+
+printf "$LIBRARY_NAME $LIBRARY_VERSION Python Library: Installer\n\n"
+
+if $UNSTABLE; then
+	warning "Installing unstable library from source.\n\n"
+else
+	printf "Installing stable library from pypi.\n\n"
+fi
+
+cd library
+
+if ! $PY3_ONLY; then
+	printf "Installing for Python 2..\n"
+	apt_pkg_install "${PY2_DEPS[@]}"
+	if $UNSTABLE; then
+		python setup.py install > /dev/null
+	else
+		pip install --upgrade $LIBRARY_NAME
+	fi
+	if [ $? -eq 0 ]; then
+		success "Done!\n"
+		echo "pip uninstall $LIBRARY_NAME" >> $UNINSTALLER
+	fi
+fi
+
+if [ -f "$PYTHON3" ]; then
+	printf "Installing for Python 3..\n"
+	apt_pkg_install "${PY3_DEPS[@]}"
+	if $UNSTABLE; then
+		python3 setup.py install > /dev/null
+	else
+		pip3 install --upgrade $LIBRARY_NAME
+	fi
+	if [ $? -eq 0 ]; then
+		success "Done!\n"
+		echo "pip3 uninstall $LIBRARY_NAME" >> $UNINSTALLER
+	fi
+else
+	if $PY3_ONLY; then
+		warning "Python 3 is required to install this library...\n"
+		exit 1
+	fi
+fi
+
+cd $WD
+
+for ((i = 0; i < ${#SETUP_CMDS[@]}; i++)); do
+	CMD="${SETUP_CMDS[$i]}"
+	# Attempt to catch anything that touches /boot/config.txt and trigger a backup
+	if [[ "$CMD" == *"raspi-config"* ]] || [[ "$CMD" == *"$CONFIG"* ]] || [[ "$CMD" == *"\$CONFIG"* ]]; then
+		do_config_backup
+	fi
+	eval $CMD
+done
+
+for ((i = 0; i < ${#CONFIG_TXT[@]}; i++)); do
+	CONFIG_LINE="${CONFIG_TXT[$i]}"
+	if ! [ "$CONFIG_LINE" == "" ]; then
+		do_config_backup
+		inform "Adding $CONFIG_LINE to $CONFIG\n"
+		sed -i "s/^#$CONFIG_LINE/$CONFIG_LINE/" $CONFIG
+		if ! grep -q "^$CONFIG_LINE" $CONFIG; then
+			printf "$CONFIG_LINE\n" >> $CONFIG
+		fi
+	fi
+done
+
+if [ -d "examples" ]; then
+	if confirm "Would you like to copy examples to $RESOURCES_DIR?"; then
+		inform "Copying examples to $RESOURCES_DIR"
+		cp -r examples/ $RESOURCES_DIR
+		echo "rm -r $RESOURCES_DIR" >> $UNINSTALLER
+		success "Done!"
+	fi
+fi
+
+printf "\n"
+
+if [ -f "/usr/bin/pydoc" ]; then
+	printf "Generating documentation.\n"
+	pydoc -w $LIBRARY_NAME > /dev/null
+	if [ -f "$LIBRARY_NAME.html" ]; then
+		cp $LIBRARY_NAME.html $RESOURCES_DIR/docs.html
+		rm -f $LIBRARY_NAME.html
+		inform "Documentation saved to $RESOURCES_DIR/docs.html"
+		success "Done!"
+	else
+		warning "Error: Failed to generate documentation."
+	fi
+fi
+
+success "\nAll done!"
+inform "If this is your first time installing you should reboot for hardware changes to take effect.\n"
+inform "Find uninstall steps in $UNINSTALLER\n"

--- a/library/.coveragerc
+++ b/library/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+source = touchphat
+omit =
+    .tox/*

--- a/library/CHANGELOG.txt
+++ b/library/CHANGELOG.txt
@@ -1,6 +1,8 @@
 0.0.2
 -----
 
+* Enhancement: Migrate to setup.cfg, linting and tidyup
+* Enhancement: Defer setup to avoid import side-effects
 * BugFix: ValueError now returned on invalid pad number or name, instead of TypeError
 
 0.0.1

--- a/library/MANIFEST.in
+++ b/library/MANIFEST.in
@@ -1,5 +1,5 @@
 include CHANGELOG.txt
 include LICENSE.txt
-include README.txt
+include README.md
 include setup.py
 include touchphat/*

--- a/library/README.md
+++ b/library/README.md
@@ -1,6 +1,11 @@
 ![Touch pHAT](touchphat-logo.png)
 https://shop.pimoroni.com/products/touch-phat
 
+[![Build Status](https://shields.io/github/workflow/status/pimoroni/touch-phat/Python%20Tests.svg)](https://github.com/pimoroni/touch-phat/actions/workflows/test.yml)
+[![Coverage Status](https://coveralls.io/repos/github/pimoroni/touch-phat/badge.svg?branch=master)](https://coveralls.io/github/pimoroni/touch-phat?branch=master)
+[![PyPi Package](https://img.shields.io/pypi/v/touchphat.svg)](https://pypi.python.org/pypi/touchphat)
+[![Python Versions](https://img.shields.io/pypi/pyversions/touchphat.svg)](https://pypi.python.org/pypi/touchphat)
+
 Touch pHAT is a simple add-on for your Pi or Pi Zero that includes 6 touch sensitive pads. Use it to add touch control to your projects.
 
 ## Installing
@@ -65,3 +70,17 @@ In all cases you will have to enable the i2c bus.
 * Function reference - http://docs.pimoroni.com/touchphat/
 * GPIO Pinout - https://pinout.xyz/pinout/touch_phat
 * Get help - http://forums.pimoroni.com/c/support
+
+# Changelog
+0.0.2
+-----
+
+* Enhancement: Migrate to setup.cfg, linting and tidyup
+* Enhancement: Defer setup to avoid import side-effects
+* BugFix: ValueError now returned on invalid pad number or name, instead of TypeError
+
+0.0.1
+-----
+
+* Initial release
+

--- a/library/README.txt
+++ b/library/README.txt
@@ -1,3 +1,0 @@
-Learn more: https://shop.pimoroni.com/products/touch-phat
-
-

--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/library/setup.cfg
+++ b/library/setup.cfg
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+[metadata]
+name = touchphat
+version = 0.0.2
+author = Philip Howard
+author_email = phil@pimoroni.com
+description = Python library for driving Pimoroni Touch pHAT
+long_description = file: README.md
+long_description_content_type = text/markdown
+keywords = Raspberry Pi LED
+url = https://www.pimoroni.com
+project_urls =
+	GitHub=https://www.github.com/pimoroni/touch-phat
+license = MIT
+# This includes the license file(s) in the wheel.
+# https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file
+license_files = LICENSE.txt
+classifiers =
+	Development Status :: 5 - Production/Stable
+	Operating System :: POSIX :: Linux
+	License :: OSI Approved :: MIT License
+	Intended Audience :: Developers
+	Programming Language :: Python :: 2.7
+	Programming Language :: Python :: 3
+	Topic :: Software Development
+	Topic :: Software Development :: Libraries
+	Topic :: System :: Hardware
+
+[options]
+python_requires = >= 2.7
+packages = touchphat
+install_requires =
+	cap1xxx >= 0.1.4
+
+[flake8]
+exclude =
+	.tox,
+	.eggs,
+	.git,
+	__pycache__,
+	build,
+	dist
+ignore =
+	E501
+
+[pimoroni]
+py3only = true
+py2deps =
+py3deps =
+configtxt =
+commands =
+	printf "Setting up i2c...\n"
+	raspi-config nonint do_i2c 0

--- a/library/setup.py
+++ b/library/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
-
+# -*- coding: utf-8 -*-
 """
-Copyright (c) 2016 Pimoroni
+Copyright (c) 2022 Pimoroni
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -22,33 +22,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup, __version__
+from pkg_resources import parse_version
 
-classifiers = ['Development Status :: 5 - Production/Stable',
-               'Operating System :: POSIX :: Linux',
-               'License :: OSI Approved :: MIT License',
-               'Intended Audience :: Developers',
-               'Programming Language :: Python :: 2.6',
-               'Programming Language :: Python :: 2.7',
-               'Programming Language :: Python :: 3',
-               'Topic :: Software Development',
-               'Topic :: System :: Hardware']
+minimum_version = parse_version('30.4.0')
 
-setup(
-    name            = 'touchphat',
-    version         = '0.0.1',
-    author          = 'Philip Howard',
-    author_email    = 'phil@pimoroni.com',
-    description     = """Python library for driving Pimoroni Touch pHAT""",
-    long_description= open('README.txt').read() + open('CHANGELOG.txt').read(),
-    license         = 'MIT',
-    keywords        = 'Raspberry Pi LED',
-    url             = 'http://www.pimoroni.com',
-    classifiers     = classifiers,
-    py_modules      = [],
-    packages        = ['touchphat'],
-    install_requires= ['cap1xxx']
-)
+if parse_version(__version__) < minimum_version:
+    raise RuntimeError("Package setuptools must be at least version {}".format(minimum_version))
+
+setup()

--- a/library/tests/conftest.py
+++ b/library/tests/conftest.py
@@ -1,0 +1,27 @@
+
+import sys
+import pytest
+import mock
+
+
+@pytest.fixture(scope='function', autouse=True)
+def cleanup():
+    """This fixture removes modules under test from sys.modules.
+    This ensures that each module is fully re-imported, along with
+    the fixtures for each test function.
+    """
+
+    yield None
+    try:
+        del sys.modules["touchphat"]
+    except KeyError:
+        pass
+
+
+@pytest.fixture(scope='function', autouse=False)
+def cap1xxx():
+    """Mock cap1xxx module."""
+    cap1xxx = mock.MagicMock()
+    sys.modules['cap1xxx'] = cap1xxx
+    yield cap1xxx
+    del sys.modules['cap1xxx']

--- a/library/tests/test_setup.py
+++ b/library/tests/test_setup.py
@@ -1,0 +1,19 @@
+import pytest
+
+
+def test_setup(cap1xxx):
+    import touchphat
+    touchphat.setup()
+
+    cap1xxx.Cap1166(i2c_addr=0x2c)._write_byte.assert_called_with(cap1xxx.R_LED_LINKING, 0b00000000)
+
+
+def test_led(cap1xxx):
+    import touchphat
+
+    for pad, led in [('Back', 5), ('A', 4), ('B', 3), ('C', 2), ('D', 1), ('Enter', 0)]:
+        touchphat.set_led(pad, False)
+        cap1xxx.Cap1166(i2c_addr=0x2c).set_led_state.assert_called_with(
+            led,
+            False
+        )

--- a/library/touchphat/__init__.py
+++ b/library/touchphat/__init__.py
@@ -1,20 +1,13 @@
-import time
-from sys import exit
+import cap1xxx
 
 
-try:
-    import cap1xxx
-except ImportError:
-    raise ImportError("This library requires the cap1xxx module\nInstall with: sudo pip install cap1xxx")
-
-
-__version__ = '0.0.1'
+__version__ = '0.0.2'
 
 
 captouch = None
 auto_leds = True
 
-PADS = list(range(1,7))
+PADS = list(range(1, 7))
 NAMES = ['Back', 'A', 'B', 'C', 'D', 'Enter']
 LEDMAP = [5, 4, 3, 2, 1, 0]
 NUMMAP = [1, 2, 3, 4, 5, 6]
@@ -22,6 +15,7 @@ NUMMAP = [1, 2, 3, 4, 5, 6]
 _on_press = [None] * 6
 _on_release = [None] * 6
 _is_setup = False
+
 
 def on_touch(pad, handler=None):
     """Register a function to be called when a pad or pads are hit.
@@ -44,6 +38,7 @@ def on_touch(pad, handler=None):
 
     _bind_handler(_on_press, pad, handler)
 
+
 def on_release(pad, handler=None):
     """Register a function to be called when a pad or pads are released.
 
@@ -65,6 +60,7 @@ def on_release(pad, handler=None):
 
     _bind_handler(_on_release, pad, handler)
 
+
 def _bind_handler(target, pad, handler):
     if type(pad) == list:
         for p in pad:
@@ -73,6 +69,7 @@ def _bind_handler(target, pad, handler):
     else:
         channel = _pad_to_channel(pad)
         target[channel] = handler
+
 
 def _pad_to_channel(pad):
     try:
@@ -83,6 +80,7 @@ def _pad_to_channel(pad):
 
     except ValueError:
         raise ValueError("Invalid touch pad {}. Should be one of \"{}\" or \"{}\"".format(pad, ', '.join(NAMES), ', '.join(str(x) for x in NUMMAP)))
+
 
 def _handle_press(event):
     global _on_press
@@ -99,6 +97,7 @@ def _handle_press(event):
         except TypeError:
             _on_press[channel]()
 
+
 def _handle_release(event):
     global _on_release
     channel = event.channel
@@ -114,6 +113,7 @@ def _handle_release(event):
         except TypeError:
             _on_release[channel]()
 
+
 def led_on(pad):
     """Turn on an LED corresponding to a single pad.
 
@@ -123,17 +123,20 @@ def led_on(pad):
 
     set_led(pad, True)
 
+
 def all_off():
     """Turn off all LEDs"""
 
     for pad in PADS:
         led_off(pad)
 
+
 def all_on():
     """Turn on all LEDs"""
 
     for pad in PADS:
         led_on(pad)
+
 
 def led_off(pad):
     """Turn off an LED corresponding to a single pad.
@@ -144,11 +147,13 @@ def led_off(pad):
 
     set_led(pad, False)
 
+
 def set_led(pad, value):
     setup()
     idx = _pad_to_channel(pad)
     led = LEDMAP[idx]
     captouch.set_led_state(led, value)
+
 
 def setup():
     global _is_setup, captouch
@@ -159,11 +164,10 @@ def setup():
     captouch = cap1xxx.Cap1166(i2c_addr=0x2c)
 
     for x in range(6):
-        captouch.on(x,event='press',   handler=_handle_press)
-        captouch.on(x,event='release', handler=_handle_release)
+        captouch.on(x, event='press', handler=_handle_press)
+        captouch.on(x, event='release', handler=_handle_release)
 
-    #"""Unlink the LEDs since Touch pHAT's LEDs don't match up with the channels"""
+    # Unlink the LEDs since Touch pHAT's LEDs don't match up with the channels
     captouch._write_byte(cap1xxx.R_LED_LINKING, 0b00000000)
 
     _is_setup = True
-

--- a/library/tox.ini
+++ b/library/tox.ini
@@ -1,0 +1,25 @@
+[tox]
+envlist = py{27,37,38,39},qa
+skip_missing_interpreters = True
+
+[testenv]
+commands =
+	python setup.py install
+	coverage run -m py.test -v -r wsx
+	coverage report
+deps =
+	mock
+	pytest>=3.1
+	pytest-cov
+
+[testenv:qa]
+commands =
+	check-manifest --ignore tox.ini,tests/*,.coveragerc
+	python setup.py sdist bdist_wheel
+	twine check dist/*
+	flake8 --ignore E501
+deps =
+	check-manifest
+	flake8
+	twine
+

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+LIBRARY_VERSION=`cat library/setup.cfg | grep version | awk -F" = " '{print $2}'`
+LIBRARY_NAME=`cat library/setup.cfg | grep name | awk -F" = " '{print $2}'`
+
+printf "$LIBRARY_NAME $LIBRARY_VERSION Python Library: Uninstaller\n\n"
+
+if [ $(id -u) -ne 0 ]; then
+	printf "Script must be run as root. Try 'sudo ./uninstall.sh'\n"
+	exit 1
+fi
+
+cd library
+
+printf "Unnstalling for Python 2..\n"
+pip uninstall $LIBRARY_NAME
+
+if [ -f "/usr/bin/pip3" ]; then
+	printf "Uninstalling for Python 3..\n"
+	pip3 uninstall $LIBRARY_NAME
+fi
+
+cd ..
+
+printf "Done!\n"


### PR DESCRIPTION
Bring Touch pHAT up-to-date with setup.cfg & Makefile tooling.

Tidy up and lint library.

Add basic test fixtures.

Bump cap1xxx version.